### PR TITLE
chore: add repository field and python keyword to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,10 +30,16 @@
     "tree-sitter",
     "ast",
     "typescript",
-    "javascript"
+    "javascript",
+    "python"
   ],
   "author": "SpecMind",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/specmind/specmind.git",
+    "directory": "packages/core"
+  },
   "dependencies": {
     "@specmind/format": "workspace:*",
     "tree-sitter": "^0.21.1",


### PR DESCRIPTION
- Add repository field with directory for monorepo support
- Add 'python' to keywords list for npm discoverability