### PR TITLE
Fix CLI to use detectLanguage() for file discovery

### DIFF
--- a/packages/cli/src/__tests__/commands/analyze.test.ts
+++ b/packages/cli/src/__tests__/commands/analyze.test.ts
@@ -19,7 +19,8 @@ vi.mock('@specmind/core', () => ({
     calls: []
   }),
   buildDependencyGraph: vi.fn().mockReturnValue([]),
-  generateComponentDiagram: vi.fn().mockReturnValue('graph TD\n  A[Component A]')
+  generateComponentDiagram: vi.fn().mockReturnValue('graph TD\n  A[Component A]'),
+  detectLanguage: vi.fn().mockReturnValue('typescript') // Mock detectLanguage to return typescript
 }))
 
 // Mock fs

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -3,7 +3,12 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
 import { join, relative } from 'path'
 import ignore from 'ignore'
-import { analyzeFile, buildDependencyGraph, generateComponentDiagram } from '@specmind/core'
+import {
+  analyzeFile,
+  buildDependencyGraph,
+  generateComponentDiagram,
+  detectLanguage,
+} from '@specmind/core'
 import type { FileAnalysis } from '@specmind/core'
 
 /**
@@ -74,7 +79,7 @@ function loadIgnorePatterns(baseDir: string): { ig: ReturnType<typeof ignore>; r
   return { ig, rootDir }
 }
 
-function getAllFiles(dir: string, extensions = ['.ts', '.tsx', '.js', '.jsx']): string[] {
+function getAllFiles(dir: string): string[] {
   const files: string[] = []
   const { ig, rootDir } = loadIgnorePatterns(dir)
 
@@ -98,7 +103,8 @@ function getAllFiles(dir: string, extensions = ['.ts', '.tsx', '.js', '.jsx']): 
         if (stat.isDirectory()) {
           traverse(fullPath)
         } else if (stat.isFile()) {
-          if (extensions.some(ext => fullPath.endsWith(ext))) {
+          // Use detectLanguage to check if file is supported
+          if (detectLanguage(fullPath)) {
             files.push(fullPath)
           }
         }


### PR DESCRIPTION
## Summary
Implements TODO section 2.1 - Fix CLI to use detectLanguage() for file discovery

This PR fixes the disconnect between core's language support and CLI's file discovery, enabling Python analysis and automatic support for future languages.

## Problem
- CLI had hardcoded file extensions `['.ts', '.tsx', '.js', '.jsx']`
- Python support exists in core but CLI didn't discover `.py` files
- Adding new languages required updating both core AND CLI

## Solution
- Import `detectLanguage()` from `@specmind/core`
- Remove hardcoded `extensions` parameter from `getAllFiles()`  
- Use `detectLanguage(fullPath)` to check if each file is supported
- CLI now automatically discovers any language supported by core

## Benefits
- ✅ **Single source of truth**: Language support defined only in core's `language-config.ts`
- ✅ **Python support**: `.py` and `.pyi` files now discovered and analyzed
- ✅ **Future-proof**: Adding Go, Rust, Java, etc. to core automatically enables CLI support
- ✅ **More maintainable**: No need to update CLI when adding languages

## Changes
- Import `detectLanguage` from `@specmind/core`
- Updated `getAllFiles()` to use `detectLanguage(fullPath)` instead of checking hardcoded extensions
- Updated test mocks to include `detectLanguage`

## Test Coverage
✅ All 25 tests passing
- Updated analyze.test.ts to mock detectLanguage
- All existing tests continue to work

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] Ready for testing on mixed Python/JS projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)