### PR TITLE
feat: implement chunked analysis for large codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ sequenceDiagram
 
 ### Current Structure
 
-For large codebases, SpecMind automatically splits analysis into services and layers:
+For large codebases, SpecMind automatically splits analysis into services and layers with chunking:
 
 ```
 .specmind/
@@ -384,31 +384,35 @@ For large codebases, SpecMind automatically splits analysis into services and la
 ├── features/                    # Feature specifications
 │   ├── user-auth.sm
 │   └── payment-flow.sm
-└── analysis/                    # Split analysis output
-    ├── metadata.json            # Overall summary
-    ├── services/                # Per-service layer analysis
-    │   ├── api-gateway/
-    │   │   ├── metadata.json
-    │   │   ├── data-layer.json
-    │   │   ├── api-layer.json
-    │   │   ├── service-layer.json
-    │   │   └── external-layer.json
-    │   └── worker-service/
-    │       ├── metadata.json
-    │       └── ...
-    └── layers/                  # Cross-service layer view
-        ├── data-layer.json      # All database interactions
-        ├── api-layer.json       # All API endpoints
-        ├── service-layer.json   # All business logic
-        └── external-layer.json  # All external integrations
+└── system/                      # Split analysis output (chunked)
+    ├── metadata.json            # Root metadata with cross-service dependencies
+    └── services/                # Per-service layer analysis
+        ├── api-gateway/
+        │   ├── metadata.json    # Service metadata with cross-layer dependencies
+        │   ├── data-layer/
+        │   │   ├── summary.json # Layer summary (pretty-printed, <50KB)
+        │   │   ├── chunk-0.json # File analysis (minified, ≤256KB)
+        │   │   └── chunk-1.json # Additional chunks as needed
+        │   ├── api-layer/
+        │   │   ├── summary.json
+        │   │   └── chunk-0.json
+        │   ├── service-layer/
+        │   │   └── ...
+        │   └── external-layer/
+        │       └── ...
+        └── worker-service/
+            ├── metadata.json
+            └── ...
 ```
 
 **Benefits:**
-- Each JSON file is small enough for LLM context windows (target: <50KB)
+- Chunked files (≤256KB) fit in LLM context windows for optimal analysis
+- Summary files provide quick layer overview without loading full data
 - Organized by architectural concerns (data/api/service/external)
 - Supports both monorepo (multiple services) and monolith (single service)
-- Cross-layer dependency tracking for architecture validation
+- Three-level dependency hierarchy (cross-service, cross-layer, same-layer)
 - Detects 180+ frameworks, ORMs, databases, and SDKs
+- Minified chunks maximize data density while keeping summaries readable
 
 See [ANALYSIS_SPLIT_SPEC.md](./docs/ANALYSIS_SPLIT_SPEC.md) for the complete specification.
 

--- a/assistants/_shared/analyze.md
+++ b/assistants/_shared/analyze.md
@@ -9,16 +9,14 @@ This prompt template contains the core logic for the `/analyze` command that ana
    npx specmind analyze
    ```
 
-2. **Review the split analysis output** in `.specmind/analysis/`:
-   - `metadata.json`: Overall summary with services, architecture type, file counts
-   - `services/{service}/`: Per-service layer analysis (data, API, service, external layers)
-   - `layers/`: Cross-service layer views showing system-wide patterns
+2. **Review the split analysis output** in `.specmind/system/`:
+   - `metadata.json`: Overall summary with services, architecture type, file counts, and cross-service dependencies
+   - `services/{service}/metadata.json`: Service metadata with cross-layer dependencies
+   - `services/{service}/{layer}/`: Per-layer chunked analysis (data, API, service, external layers)
 
-   Each layer file contains:
-   - Files in that layer with their functions, classes, and imports
-   - Internal dependencies (within the layer)
-   - Cross-layer dependencies (to other layers)
-   - Layer-specific metadata (databases, APIs, external services, etc.)
+   Each layer directory contains:
+   - `summary.json`: Layer overview with chunk manifest, cross-layer dependencies, and layer-specific metadata (databases, APIs, external services)
+   - `chunk-N.json`: File analysis chunks (≤256KB each, minified) with files, functions, classes, imports, and same-layer dependencies
 
 3. **Analyze the split structure** to understand:
    - **Services**: How many services exist (monorepo vs monolith)

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -22,7 +22,7 @@ import type { FileAnalysis } from '@specmind/core'
 
 export interface AnalyzeOptions {
   path?: string
-  output?: string // Output directory for analysis (default: .specmind/analysis)
+  output?: string // Output directory for analysis (default: .specmind/system)
 }
 
 /**
@@ -152,7 +152,7 @@ export async function analyzeCommand(options: AnalyzeOptions = {}) {
     const dependencies = buildDependencyGraph(analyses)
 
     // Perform split analysis
-    const outputDir = options.output || join(targetPath, '.specmind/analysis')
+    const outputDir = options.output || join(targetPath, '.specmind/system')
     await performSplitAnalysis(targetPath, analyses, dependencies, outputDir)
   } catch (error) {
     console.error('Error analyzing codebase:', error instanceof Error ? error.message : error)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ program
   .command('analyze')
   .description('Analyze codebase and generate architecture diagram')
   .option('-p, --path <path>', 'Path to analyze', process.cwd())
-  .option('-o, --output <dir>', 'Output directory for analysis (default: .specmind/analysis)')
+  .option('-o, --output <dir>', 'Output directory for analysis (default: .specmind/system)')
   .action(async (options) => {
     await analyzeCommand(options)
   })

--- a/packages/core/src/__tests__/split-analyzer.test.ts
+++ b/packages/core/src/__tests__/split-analyzer.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { performSplitAnalysis } from '../analyzer/split-analyzer.js'
+import type { FileAnalysis, ModuleDependency } from '../types/index.js'
+
+describe('Split Analyzer - Chunking', () => {
+  const testOutputDir = join(__dirname, '__test-output__')
+
+  beforeEach(() => {
+    // Clean up test output directory
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true })
+    }
+    mkdirSync(testOutputDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    // Clean up after tests
+    if (existsSync(testOutputDir)) {
+      rmSync(testOutputDir, { recursive: true })
+    }
+  })
+
+  it('should create .specmind/system directory structure', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/index.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    expect(existsSync(testOutputDir)).toBe(true)
+    expect(existsSync(join(testOutputDir, 'metadata.json'))).toBe(true)
+    expect(existsSync(join(testOutputDir, 'services'))).toBe(true)
+  })
+
+  it('should create layer directories instead of layer files', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [
+          {
+            name: 'processData',
+            qualifiedName: 'processData',
+            parameters: [],
+            isExported: true,
+            isAsync: false,
+            location: {
+              filePath: '/test/src/service.ts',
+              startLine: 1,
+              endLine: 3,
+            },
+          },
+        ],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = existsSync(join(testOutputDir, 'services'))
+      ? require('fs').readdirSync(join(testOutputDir, 'services'))
+      : []
+
+    expect(serviceDirs.length).toBeGreaterThan(0)
+
+    const firstService = serviceDirs[0]
+    const serviceDir = join(testOutputDir, 'services', firstService)
+
+    // Should have layer directories, not layer files
+    expect(existsSync(join(serviceDir, 'service-layer'))).toBe(true)
+    expect(existsSync(join(serviceDir, 'service-layer.json'))).toBe(false)
+  })
+
+  it('should create summary.json and chunk files in each layer directory', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [
+          {
+            name: 'processData',
+            qualifiedName: 'processData',
+            parameters: [],
+            isExported: true,
+            isAsync: false,
+            location: {
+              filePath: '/test/src/service.ts',
+              startLine: 1,
+              endLine: 3,
+            },
+          },
+        ],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const serviceLayerDir = join(testOutputDir, 'services', firstService, 'service-layer')
+
+    expect(existsSync(join(serviceLayerDir, 'summary.json'))).toBe(true)
+    expect(existsSync(join(serviceLayerDir, 'chunk-0.json'))).toBe(true)
+  })
+
+  it('should pretty-print summary.json files', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const summaryPath = join(testOutputDir, 'services', firstService, 'service-layer', 'summary.json')
+
+    const summaryContent = readFileSync(summaryPath, 'utf-8')
+
+    // Pretty-printed JSON should have newlines and indentation
+    expect(summaryContent).toContain('\n')
+    expect(summaryContent).toContain('  ') // 2-space indentation
+  })
+
+  it('should minify chunk files (no whitespace)', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const chunkPath = join(testOutputDir, 'services', firstService, 'service-layer', 'chunk-0.json')
+
+    const chunkContent = readFileSync(chunkPath, 'utf-8')
+
+    // Minified JSON should not have unnecessary whitespace
+    // Check that it doesn't have the pretty-print pattern of newline + 2 spaces
+    expect(chunkContent).not.toMatch(/\n  /)
+  })
+
+  it('should include chunkManifest in summary.json', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service1.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+      {
+        filePath: '/test/src/service2.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const summaryPath = join(testOutputDir, 'services', firstService, 'service-layer', 'summary.json')
+
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'))
+
+    expect(summary.chunkManifest).toBeDefined()
+    expect(Array.isArray(summary.chunkManifest)).toBe(true)
+    expect(summary.chunkManifest.length).toBeGreaterThan(0)
+    expect(summary.chunkManifest[0]).toHaveProperty('chunkIndex')
+    expect(summary.chunkManifest[0]).toHaveProperty('fileCount')
+    expect(summary.chunkManifest[0]).toHaveProperty('files')
+  })
+
+  it('should include crossLayerDependencies in service metadata', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const metadataPath = join(testOutputDir, 'services', firstService, 'metadata.json')
+
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+
+    expect(metadata.crossLayerDependencies).toBeDefined()
+    expect(typeof metadata.crossLayerDependencies).toBe('object')
+  })
+
+  it('should include crossServiceDependencies in root metadata', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const metadataPath = join(testOutputDir, 'metadata.json')
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+
+    expect(metadata.crossServiceDependencies).toBeDefined()
+    expect(typeof metadata.crossServiceDependencies).toBe('object')
+  })
+
+  it('should NOT create layers/ directory', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    // The old structure had a layers/ directory - verify it doesn't exist
+    expect(existsSync(join(testOutputDir, 'layers'))).toBe(false)
+  })
+
+  it('should create multiple chunks when files exceed 256KB', async () => {
+    // Create a large mock file that will exceed chunk size
+    const largeFunction = {
+      name: 'largeFunction',
+      qualifiedName: 'largeFunction',
+      parameters: Array.from({ length: 100 }, (_, i) => ({
+        name: `param${i}`,
+        type: 'string',
+        optional: false,
+      })),
+      isExported: true,
+      isAsync: false,
+      location: {
+        filePath: '/test/src/large.ts',
+        startLine: 1,
+        endLine: 1000,
+      },
+    }
+
+    // Create many files with large functions to exceed 256KB
+    const mockAnalyses: FileAnalysis[] = Array.from({ length: 50 }, (_, i) => ({
+      filePath: `/test/src/file${i}.ts`,
+      language: 'typescript' as const,
+      functions: Array(20).fill(largeFunction),
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+    }))
+
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const serviceLayerDir = join(testOutputDir, 'services', firstService, 'service-layer')
+
+    const files = require('fs').readdirSync(serviceLayerDir)
+    const chunkFiles = files.filter((f: string) => f.startsWith('chunk-'))
+
+    // Should create multiple chunks
+    expect(chunkFiles.length).toBeGreaterThan(1)
+
+    // Verify chunk sizes are under 256KB
+    chunkFiles.forEach((chunkFile: string) => {
+      const chunkPath = join(serviceLayerDir, chunkFile)
+      const stats = require('fs').statSync(chunkPath)
+      expect(stats.size).toBeLessThanOrEqual(256 * 1024)
+    })
+  })
+
+  it('should include totalChunks in summary', async () => {
+    const mockAnalyses: FileAnalysis[] = [
+      {
+        filePath: '/test/src/service.ts',
+        language: 'typescript',
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        calls: [],
+      },
+    ]
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const summaryPath = join(testOutputDir, 'services', firstService, 'service-layer', 'summary.json')
+
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'))
+
+    expect(summary.totalChunks).toBeDefined()
+    expect(typeof summary.totalChunks).toBe('number')
+    expect(summary.totalChunks).toBeGreaterThan(0)
+  })
+
+  it('should enforce 256KB chunk size limit strictly', async () => {
+    // Create files with known sizes to verify chunking threshold
+    const largeFunction = {
+      name: 'largeFunction',
+      qualifiedName: 'largeFunction',
+      parameters: Array.from({ length: 100 }, (_, i) => ({
+        name: `param${i}`,
+        type: 'string',
+        optional: false,
+      })),
+      isExported: true,
+      isAsync: false,
+      location: {
+        filePath: '/test/src/large.ts',
+        startLine: 1,
+        endLine: 1000,
+      },
+    }
+
+    // Create many files to ensure we hit the chunk limit
+    const mockAnalyses: FileAnalysis[] = Array.from({ length: 100 }, (_, i) => ({
+      filePath: `/test/src/file${i}.ts`,
+      language: 'typescript' as const,
+      functions: Array(20).fill(largeFunction),
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+    }))
+
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const serviceLayerDir = join(testOutputDir, 'services', firstService, 'service-layer')
+
+    const files = require('fs').readdirSync(serviceLayerDir)
+    const chunkFiles = files.filter((f: string) => f.startsWith('chunk-'))
+
+    // Verify EVERY chunk is under 256KB (262144 bytes)
+    const MAX_CHUNK_SIZE = 256 * 1024
+    let violatingChunks = 0
+
+    chunkFiles.forEach((chunkFile: string) => {
+      const chunkPath = join(serviceLayerDir, chunkFile)
+      const stats = require('fs').statSync(chunkPath)
+
+      if (stats.size > MAX_CHUNK_SIZE) {
+        violatingChunks++
+        console.error(`❌ Chunk ${chunkFile} exceeds limit: ${stats.size} bytes (limit: ${MAX_CHUNK_SIZE})`)
+      }
+    })
+
+    expect(violatingChunks).toBe(0)
+
+    // Also verify that at least some chunks exist (proving chunking happened)
+    expect(chunkFiles.length).toBeGreaterThan(0)
+  })
+
+  it('should keep summary.json files small (target <50KB)', async () => {
+    // Create moderate-sized dataset
+    const mockAnalyses: FileAnalysis[] = Array.from({ length: 20 }, (_, i) => ({
+      filePath: `/test/src/file${i}.ts`,
+      language: 'typescript' as const,
+      functions: [
+        {
+          name: `func${i}`,
+          qualifiedName: `func${i}`,
+          parameters: [],
+          isExported: true,
+          isAsync: false,
+          location: {
+            filePath: `/test/src/file${i}.ts`,
+            startLine: 1,
+            endLine: 10,
+          },
+        },
+      ],
+      classes: [],
+      imports: [],
+      exports: [],
+      calls: [],
+    }))
+
+    const mockDeps: ModuleDependency[] = []
+
+    await performSplitAnalysis('/test', mockAnalyses, mockDeps, testOutputDir)
+
+    const serviceDirs = require('fs').readdirSync(join(testOutputDir, 'services'))
+    const firstService = serviceDirs[0]
+    const serviceLayerDir = join(testOutputDir, 'services', firstService, 'service-layer')
+    const summaryPath = join(serviceLayerDir, 'summary.json')
+
+    const stats = require('fs').statSync(summaryPath)
+
+    // Summary should be significantly smaller than 256KB
+    // Target is <50KB, but we'll allow up to 100KB for this test
+    expect(stats.size).toBeLessThan(100 * 1024)
+  })
+})


### PR DESCRIPTION
## Summary

Implements chunking for split analysis to handle very large codebases that exceed LLM context windows (256KB Read tool limit).

## Problem

The existing split analysis generates layer files (e.g., `data-layer.json`) that can exceed 1.3MB, which breaks the LLM workflow since the Read tool has a 256KB limit. Additionally, the `layers/` directory was duplicating all data from `services/`.

## Solution

### Chunking Architecture
- Split layer files into ≤256KB chunks (minified JSON)
- Create summary files (<50KB target, pretty-printed) with chunk manifests
- Three-level dependency hierarchy:
  - **Root metadata**: Cross-service dependencies (how services talk to each other)
  - **Service metadata**: Cross-layer dependencies (how layers talk within service)
  - **Chunk files**: Same-layer dependencies (how files talk within same layer)

### New Output Structure
```
.specmind/system/                      # Changed from .specmind/analysis/
├── metadata.json                      # Cross-service dependencies
└── services/{service}/
    ├── metadata.json                  # Cross-layer dependencies
    └── {layer}/                       # Changed from {layer}.json files
        ├── summary.json               # Layer overview (pretty, <50KB)
        └── chunk-N.json               # File analysis (minified, ≤256KB)
```

### Key Features
- ✅ Chunks are minified to maximize data density
- ✅ Summaries are pretty-printed for readability
- ✅ Chunk manifest helps LLMs discover which files are in which chunk
- ✅ Removed redundant `layers/` directory (was duplicating services/ data)
- ✅ Renamed output directory from `analysis/` to `system/`

## Changes

### Code Implementation
- `packages/core/src/analyzer/split-analyzer.ts`:
  - Added `chunkFileAnalyses()` function with 256KB threshold
  - Updated `performSplitAnalysis()` to write chunked layer directories
  - Removed global `layers/` directory generation
  - Added cross-service and cross-layer dependency tracking

- `packages/cli/src/commands/analyze.ts` & `packages/cli/src/index.ts`:
  - Changed default output from `.specmind/analysis/` to `.specmind/system/`

### Documentation Updates
- `docs/ANALYSIS_SPLIT_SPEC.md`: Complete rewrite with chunking specification
- `CONSTITUTION.md`: Bumped to v1.9.0 with detailed chunking architecture
- `README.md`: Updated project structure section
- `assistants/_shared/analyze.md`: Updated for new output format

### Test Coverage
- Added `packages/core/src/__tests__/split-analyzer.test.ts` with 13 tests:
  - Directory structure validation
  - Layer directories vs files
  - Summary and chunk file creation
  - Pretty-printing vs minification
  - Chunk manifest validation
  - Cross-layer/cross-service dependencies
  - 256KB chunk size enforcement (strict validation)
  - Summary file size limits (<100KB)
  - Multiple chunk creation for large datasets

**Test Results**: ✅ All 256 tests pass (13 new, 243 existing - no regressions)

## Testing

Tested with:
- 694-file real-world codebase with 103 services
- Generated 50+ chunks for large services
- All chunks confirmed under 256KB limit
- Summary files well under 100KB

## Breaking Changes

⚠️ **Output Location**: `.specmind/analysis/` → `.specmind/system/`
⚠️ **Layer Format**: `{layer}-layer.json` → `{layer}-layer/` (directory with summary + chunks)
⚠️ **Removed**: Global `layers/` directory (was redundant)

## Benefits

1. **LLM-Friendly**: All files now fit within 256KB Read tool limit
2. **No Data Loss**: Same information, just split into manageable chunks
3. **Better Organization**: Three-level dependency hierarchy is clearer
4. **Efficient Storage**: Minified chunks maximize data density
5. **Easy Discovery**: Summary files provide quick overview and chunk manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)