### PR TITLE
Add zoom and fullscreen to diagram viewer using svg-pan-zoom

### DIFF
--- a/packages/vscode/src/previewPanel.ts
+++ b/packages/vscode/src/previewPanel.ts
@@ -476,12 +476,6 @@ export class SpecMindPreviewPanel {
 
                         // Resize pan-zoom after fullscreen toggle
                         setTimeout(() => {
-                            // Update SVG dimensions to match container
-                            const newWidth = container.clientWidth;
-                            const newHeight = container.clientHeight;
-                            svg.setAttribute('width', newWidth);
-                            svg.setAttribute('height', newHeight);
-
                             panZoomInstance.resize();
                             panZoomInstance.fit();
                             panZoomInstance.center();
@@ -500,12 +494,6 @@ export class SpecMindPreviewPanel {
                             fullscreenBtn.title = 'Fullscreen';
                         }
                         setTimeout(() => {
-                            // Update SVG dimensions to match container
-                            const newWidth = container.clientWidth;
-                            const newHeight = container.clientHeight;
-                            svg.setAttribute('width', newWidth);
-                            svg.setAttribute('height', newHeight);
-
                             panZoomInstance.resize();
                             panZoomInstance.fit();
                             panZoomInstance.center();


### PR DESCRIPTION
## Summary

Adds interactive zoom and fullscreen capabilities to Mermaid diagrams in the VS Code extension using the industry-standard `svg-pan-zoom` library (same library used by GitHub, GitLab, etc.).

**Features:**
- ✅ Zoom in/out buttons with visual feedback
- ✅ Mouse wheel zoom support
- ✅ Click and drag to pan (library-handled)
- ✅ Double-click to zoom
- ✅ Reset zoom button
- ✅ Fullscreen mode toggle
- ✅ ESC key to exit fullscreen
- ✅ Live zoom percentage display (10% - 1000%)
- ✅ Automatic fit and center on fullscreen
- ✅ Touch/gesture support (mobile-ready)

**Why svg-pan-zoom?**
- Battle-tested library used by GitHub, GitLab, and many professional tools
- Better performance and edge case handling than custom implementation
- Proper touch/gesture support out of the box
- Active maintenance and bug fixes
- Users get familiar GitHub-like experience

**UI Controls:**
Each Mermaid diagram gets a control panel in the top-right corner:
- 🔍+ Zoom In
- 🔍- Zoom Out  
- ⟲ Reset Zoom
- [100%] Live zoom level
- ⛶ Fullscreen (changes to ✕ when active)

## Test Plan

- [x] Build succeeds (`pnpm --filter=specmind-vscode build`)
- [x] Diagrams render correctly
- [x] Control buttons work (zoom in/out/reset)
- [x] Mouse wheel zoom works
- [x] Click and drag pan works (library-handled)
- [x] Fullscreen toggle works
- [x] ESC exits fullscreen
- [x] Zoom level display updates correctly
- [x] Multiple diagrams on same page work independently

## Implementation

**Library Used:** `svg-pan-zoom@3.6.1` from CDN
**Changes:** Single file - `packages/vscode/src/previewPanel.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)