### PR TITLE
Fix VSCode extension diagram controls

### DIFF
--- a/packages/vscode/src/previewPanel.ts
+++ b/packages/vscode/src/previewPanel.ts
@@ -208,21 +208,22 @@ export class SpecMindPreviewPanel {
                 padding: 0;
                 margin: 20px 0;
                 position: relative;
-                overflow: hidden;
+                overflow: visible;
                 height: 600px;
                 box-sizing: border-box;
 
                 /* Break free from all parent constraints */
-                width: 100vw;
-                margin-left: -20px;
+                width: calc(100vw - 40px);
+                max-width: 100%;
             }
             .section-content .mermaid-container {
                 /* Account for section-content margin-left: 10px */
-                margin-left: -30px;
+                margin-left: -10px;
             }
             .mermaid-container .mermaid-diagram {
                 width: 100%;
                 height: 100%;
+                overflow: hidden;
             }
             .mermaid-container .mermaid-diagram svg {
                 display: block;
@@ -247,7 +248,9 @@ export class SpecMindPreviewPanel {
             .mermaid-container.fullscreen .diagram-controls {
                 position: fixed;
                 top: 20px;
-                right: 20px;
+                right: 10px;
+                left: auto;
+                max-width: calc(100vw - 20px);
                 z-index: 10001;
             }
             .mermaid-container.fullscreen .mermaid-diagram {


### PR DESCRIPTION
## Summary
Fix diagram control panel positioning and interaction issues in the VSCode extension preview.

## Changes

### 1. Disable Gesture Zoom (892ab8e)
- Disable `mouseWheelZoomEnabled` to prevent unwanted trackpad gesture zoom
- Keep double-click zoom enabled for quick zoom functionality
- Maintain pan functionality with left mouse button drag
- Improve user control over zoom behavior

### 2. Fix Duplicate Controls in Fullscreen (892ab8e)
- Hide non-fullscreen diagrams when one diagram is in fullscreen mode
- Prevent duplicate control panels from appearing in fullscreen view
- Add CSS rule: `body.fullscreen-mode .mermaid-container:not(.fullscreen) { display: none; }`

### 3. Fix Controls Viewport Positioning (500b79e)
- Change container width from `100vw` to `calc(100vw - 40px)` to account for body padding
- Move `overflow: hidden` from container to inner diagram element to prevent control clipping
- Adjust section-content margins to compensate for new container width
- Ensure controls stay within viewport boundaries in both normal and fullscreen modes

## Testing
- ✅ Controls visible in normal mode
- ✅ Controls visible and properly positioned in fullscreen mode
- ✅ No duplicate controls when multiple diagrams present
- ✅ Gesture zoom disabled, manual controls work
- ✅ Pan with left mouse button works
- ✅ Double-click zoom works

🤖 Generated with [Claude Code](https://claude.com/claude-code)