### PR TITLE
Fix #23: Use tiktoken for accurate token counting

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@specmind/format": "workspace:^",
+    "js-tiktoken": "^1.0.21",
     "minimatch": "^10.0.3",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.21.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@specmind/format':
         specifier: workspace:^
         version: link:../format
+      js-tiktoken:
+        specifier: ^1.0.21
+        version: 1.0.21
       minimatch:
         specifier: ^10.0.3
         version: 10.0.3
@@ -1646,6 +1649,9 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3313,8 +3319,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   binaryextensions@6.11.0:
     dependencies:
@@ -4109,6 +4114,10 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary

Fixes #23 by replacing naive character-based token estimation with accurate token counting using `js-tiktoken`.

## Problem

Chunk files were exceeding Claude's 25K token limit when read by the Read tool, causing errors:
```
File content (25352 tokens) exceeds maximum allowed tokens (25000)
```

The previous implementation used a naive `CHARS_PER_TOKEN = 4` estimation that was inaccurate because it didn't account for how tokenizers actually work (BPE - byte pair encoding).

## Solution

### Provider-Agnostic Approach

Used `js-tiktoken` with `cl100k_base` encoding as a **universal approximation** that works across different LLM providers (Claude, GPT-4, Gemini):
- More accurate than character counting
- Close enough for all modern LLMs that use similar BPE-based tokenization
- Large safety margin accounts for provider differences

### Conservative Limits

- Reduced `MAX_CHUNK_TOKENS` from **20K to 18K** (7K buffer instead of 5K)
- This conservative limit ensures chunks stay well under Claude's 25K Read tool limit
- Safety margin accounts for tokenization differences between providers

### Implementation Details

```typescript
// Before: naive character estimation
const CHARS_PER_TOKEN = 4;
function estimateTokens(text: string): number {
  return Math.ceil(text.length / CHARS_PER_TOKEN);
}

// After: accurate BPE tokenization
import { getEncoding } from 'js-tiktoken';
const tokenizer = getEncoding('cl100k_base');
function countTokens(text: string): number {
  const tokens = tokenizer.encode(text);
  return tokens.length;
}
```

## Testing

- ✅ All existing tests pass (258 tests)
- ✅ Tested locally with packages/core/src (38 files → 25 chunks)
- ✅ Chunking logic working correctly
- ✅ Analysis completes successfully

## Changes

- Add `js-tiktoken` dependency to `@specmind/core`
- Replace character-based estimation with actual tokenization in `split-analyzer.ts`
- Update `MAX_CHUNK_TOKENS` from 20K to 18K
- Add detailed documentation explaining provider-agnostic approach

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)