### PR TITLE
Fix: Clarify Mermaid ER diagrams only support single field markers

### DIFF
--- a/assistants/_shared/analyze.md
+++ b/assistants/_shared/analyze.md
@@ -126,6 +126,8 @@ Analyzes a codebase and creates system architecture documentation.
    - Read entities from ALL `.specmind/system/services/{service}/data-layer/entities-chunk-*.json` files
    - Show ALL entities with all fields
    - Include field type markers: PK (primary key), UK (unique key), FK (foreign key)
+   - **IMPORTANT**: Only ONE marker per field - Mermaid doesn't support multiple markers (e.g., "FK UK" will error)
+   - For foreign keys that are also unique (1:1 relationships), use FK and let the relationship cardinality (||--||) indicate uniqueness
    - Show relationships using Mermaid notation:
      - `||--o{` for oneToMany (one has many)
      - `}o--||` for manyToOne (many belong to one)

--- a/assistants/_shared/design.md
+++ b/assistants/_shared/design.md
@@ -142,7 +142,9 @@ This prompt template contains the core logic for the `/design <feature-name>` co
              - 🟢 New entities: `style NewEntity fill:#4c5a2b,stroke:#3d4722,stroke-width:2px`
              - 🟠 Modified entities: `style ModifiedEntity fill:#d97706,stroke:#b45309,stroke-width:2px`
              - 🔴 Removed entities: `style RemovedEntity fill:#701f1c,stroke:#5a1916,stroke-width:2px`
-           - Show all fields with PK/UK/FK markers
+           - Show all fields with type markers (PK, UK, or FK - **only ONE marker per field**)
+           - **IMPORTANT**: Mermaid only supports single markers - use PK for primary keys, FK for foreign keys, UK for unique keys
+           - For foreign keys that are also unique (1:1 relationships), use FK and let the relationship cardinality (||--||) indicate uniqueness
            - Show relationships using Mermaid notation:
              - `oneToMany` (||--o{): One entity has many related entities
              - `manyToOne` (}o--||): Many entities belong to one entity


### PR DESCRIPTION
## Summary
Prevents AI assistants from generating invalid ER diagrams with multiple field markers (e.g., `FK UK`) which causes Mermaid parse errors.

## Problem
The `/design` command was generating ER diagrams like:
```mermaid
ReminderPreferences {
    int user_id FK UK "🟢 NEW"
}
```

This causes Mermaid parse error:
```
Parse error on line 40:
...     int user_id FK UK "🟢 NEW"        
-----------------------^
Expecting 'BLOCK_STOP', 'ATTRIBUTE_WORD', ',', 'COMMENT', got 'ATTRIBUTE_KEY'
```

## Root Cause
Mermaid ER diagrams only support **one marker per field**: PK, UK, or FK (not combinations).

The prompts didn't explicitly state this limitation, so AI would naturally try to be comprehensive by adding both FK and UK for foreign keys in one-to-one relationships.

## Solution
Updated both `analyze.md` and `design.md` to:
- Explicitly warn: **"Only ONE marker per field"**
- Provide example of invalid syntax: `"FK UK" will error`
- Clarify best practice: Use `FK` for one-to-one foreign keys and let the relationship cardinality (`||--||`) indicate uniqueness

## Changes
- **analyze.md**: Added 2 lines clarifying single marker limitation
- **design.md**: Added 3 lines with same guidance

## Test Plan
- [x] Updated prompts with clear guidance
- [ ] Test with `/design` command on feature requiring 1:1 relationships
- [ ] Verify generated ER diagrams use single markers only

🤖 Generated with [Claude Code](https://claude.com/claude-code)