### PR TITLE
Add Cursor support with custom prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All `.sm` files use Markdown + Mermaid diagrams and can be viewed with the SpecM
 
 > **Note:** SpecMind is currently in active development. Star the repo to follow progress!
 
-> **Requirements:** Currently supports **Claude Code** and **Windsurf**. Support for Cursor and GitHub Copilot coming soon.
+> **Requirements:** Currently supports **Claude Code**, **Windsurf**, and **Cursor**. Support for GitHub Copilot coming soon.
 
 ### Installation
 
@@ -79,6 +79,9 @@ npx specmind setup claude-code
 # For Windsurf
 npx specmind setup windsurf
 
+# For Cursor
+npx specmind setup cursor
+
 # Or interactive mode - choose your assistant(s)
 npx specmind setup
 
@@ -90,6 +93,7 @@ specmind setup claude-code  # or windsurf
 This copies the assistant files to your project:
 - Claude Code: `.claude/commands/` (slash commands)
 - Windsurf: `.windsurf/workflows/` (Cascade workflows)
+- Cursor: `.cursor/prompts/` (custom prompts)
 
 **Step 2: Install VS Code extension (optional)**
 
@@ -109,6 +113,12 @@ Search "SpecMind" in VS Code extensions marketplace for visual .sm file renderin
 /analyze
 ```
 
+**In Cursor** (custom prompts):
+
+```
+@analyze
+```
+
 The AI will analyze your codebase and create `.specmind/system.sm` with your architecture.
 
 **Design a feature:**
@@ -121,6 +131,11 @@ Claude Code:
 Windsurf:
 ```
 /design Real-time Notifications
+```
+
+Cursor:
+```
+@design Real-time Notifications
 ```
 
 You can provide either:
@@ -151,6 +166,11 @@ Windsurf:
 /implement Real-time Notifications
 ```
 
+Cursor:
+```
+@implement Real-time Notifications
+```
+
 The AI uses the `.sm` file as context to implement code that aligns with your architecture.
 
 ---
@@ -171,7 +191,7 @@ SpecMind uses slash commands that are specific to each AI coding assistant. Here
 |--------------|--------|----------------------|----------|
 | **Claude Code** | ✅ Supported | `.claude/commands/` invoking `npx specmind` | `/analyze`, `/design`, `/implement` |
 | **Windsurf** | ✅ Supported | `.windsurf/workflows/` Cascade workflows with shared prompts | `/analyze`, `/design`, `/implement` |
-| **Cursor** | 🚧 Coming Soon | `.cursorrules` + bash invocation | Planned |
+| **Cursor** | ✅ Supported | `.cursor/prompts/` custom prompts with shared templates | `@analyze`, `@design`, `@implement` |
 | **GitHub Copilot** | 🚧 Coming Soon | Custom prompts + bash invocation | Planned |
 
 Each AI assistant requires its own implementation method, but all use the same shared prompt templates for consistency.
@@ -430,8 +450,8 @@ specmind/
 ├── assistants/     # AI assistant integrations
 │   ├── _shared/    # Shared prompt templates (✅ Implemented)
 │   ├── claude-code/  # Claude Code integration (✅ Implemented)
-│   ├── cursor/       # Cursor integration (🚧 Planned)
-│   ├── windsurf/     # Windsurf integration (🚧 Planned)
+│   ├── cursor/       # Cursor integration (✅ Implemented)
+│   ├── windsurf/     # Windsurf integration (✅ Implemented)
 │   └── copilot/      # Copilot integration (🚧 Planned)
 ├── packages/
 │   ├── core/       # @specmind/core - Analysis engine (✅ Implemented)

--- a/assistants/cursor/.cursor/prompts/analyze.md
+++ b/assistants/cursor/.cursor/prompts/analyze.md
@@ -1,0 +1,7 @@
+---
+description: Analyze codebase and create system architecture documentation
+---
+
+You are implementing the `/analyze` command for SpecMind.
+
+{{file:../_shared/analyze.md}}

--- a/assistants/cursor/.cursor/prompts/design.md
+++ b/assistants/cursor/.cursor/prompts/design.md
@@ -1,0 +1,7 @@
+---
+description: Design a new feature with architecture specification
+---
+
+You are implementing the `/design` command for SpecMind.
+
+{{file:../_shared/design.md}}

--- a/assistants/cursor/.cursor/prompts/implement.md
+++ b/assistants/cursor/.cursor/prompts/implement.md
@@ -1,0 +1,7 @@
+---
+description: Implement a feature based on its architecture spec
+---
+
+You are implementing the `/implement` command for SpecMind.
+
+{{file:../_shared/implement.md}}

--- a/assistants/cursor/README.md
+++ b/assistants/cursor/README.md
@@ -1,20 +1,88 @@
 # SpecMind for Cursor
 
-🚧 **Coming Soon**
+SpecMind integrates with Cursor using custom prompts in the `.cursor/prompts/` directory.
 
-Cursor integration will use `.cursorrules` and custom commands to provide SpecMind functionality.
+## Installation
 
-## Planned Installation
+From your project root:
 
 ```bash
-# From your project root
 npx specmind setup cursor
 ```
 
-## Planned Commands
+This will copy the SpecMind prompts to `.cursor/prompts/` in your project.
 
-- `/init` - Initialize SpecMind and analyze your codebase
-- `/design <feature-name>` - Design a new feature with architecture spec
-- `/implement <feature-name>` - Implement a feature based on its spec
+## Available Commands
 
-Stay tuned for updates!
+### `/analyze` - Analyze Codebase
+
+Analyzes your entire codebase and generates architecture documentation in `.specmind/system/`.
+
+**Usage:**
+1. Open Cursor Chat (Cmd/Ctrl + L)
+2. Type `@analyze`
+3. Follow the prompts
+
+**What it does:**
+- Detects services (monolith or microservices)
+- Extracts API endpoints, database models, message queues
+- Generates architectural diagrams (Mermaid)
+- Creates `.specmind/system/` with full analysis
+
+### `/design <feature-name>` - Design Feature
+
+Designs a new feature with a complete architecture spec before implementation.
+
+**Usage:**
+1. Open Cursor Chat
+2. Type `@design user-authentication`
+3. Describe what you want to build
+
+**What it does:**
+- Creates `.specmind/features/<feature-name>.sm`
+- Generates Mermaid diagrams for the feature
+- Documents data models, API contracts, dependencies
+- Provides implementation plan
+
+### `/implement <feature-name>` - Implement Feature
+
+Implements a feature based on its existing `.sm` spec file.
+
+**Usage:**
+1. Open Cursor Chat
+2. Type `@implement user-authentication`
+3. The AI will follow the architecture spec
+
+**What it does:**
+- Reads `.specmind/features/<feature-name>.sm`
+- Implements code following the documented architecture
+- Creates all necessary files (models, routes, services, tests)
+- Ensures alignment with existing system architecture
+
+## Tips
+
+- Run `/analyze` first to understand your codebase
+- Use `/design` before building new features
+- Reference `.specmind/` files in your prompts for architectural context
+- Update `.sm` files as your system evolves
+
+## File Structure
+
+After setup, your project will have:
+
+```
+your-project/
+├── .cursor/
+│   └── prompts/
+│       ├── analyze.md
+│       ├── design.md
+│       └── implement.md
+└── .specmind/           # Generated after /analyze
+    ├── system/          # Full system analysis
+    └── features/        # Feature specs (after /design)
+```
+
+## Learn More
+
+- [SpecMind Documentation](https://github.com/specmind/specmind)
+- [.sm File Format](https://github.com/specmind/specmind/blob/main/CONSTITUTION.md)

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -21,9 +21,9 @@ const ASSISTANT_CONFIGS = {
     description: 'Claude Code slash commands'
   },
   cursor: {
-    source: '.cursorrules',
-    dest: '.cursorrules',
-    description: 'Cursor rules and commands'
+    source: '.cursor',
+    dest: '.cursor',
+    description: 'Cursor custom prompts'
   },
   windsurf: {
     source: '.windsurf',


### PR DESCRIPTION
Implements Cursor integration using custom prompts in .cursor/prompts/ directory.

Features:
- Created .cursor/prompts/ structure with analyze, design, implement commands
- Updated setup command to support 'cursor' assistant
- Commands use @ prefix in Cursor (e.g., @analyze, @design, @implement)
- Updated README to list Cursor as supported alongside Claude Code and Windsurf

File structure:
- assistants/cursor/.cursor/prompts/analyze.md
- assistants/cursor/.cursor/prompts/design.md
- assistants/cursor/.cursor/prompts/implement.md
- assistants/cursor/README.md (updated with full instructions)

Usage:
```bash
npx specmind setup cursor
```

This copies .cursor/prompts/ to the project, enabling:
- @analyze - Analyze codebase architecture
- @design <feature-name> - Design new features
- @implement <feature-name> - Implement features from specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)